### PR TITLE
Add simple i18n context

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,10 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
    /* config options here */
+   i18n: {
+      locales: ['fr', 'en'],
+      defaultLocale: 'fr'
+   },
    typescript: {
       // ignoreBuildErrors: true
    }

--- a/src/app/components/BackToProjectsButton.tsx
+++ b/src/app/components/BackToProjectsButton.tsx
@@ -1,9 +1,11 @@
 "use client"
 
 import { useRouter } from 'next/navigation';
+import { useTranslation } from '@/context/I18nContext';
 
 const BackToProjectsButton = () => {
   const router = useRouter();
+  const { t } = useTranslation();
 
   const handleClick = () => {
     router.push('/?scrollToProjets=1');
@@ -17,9 +19,8 @@ const BackToProjectsButton = () => {
       <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path d="M11.25 15L6.25 10L11.25 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
       </svg>
-      <span className="font-semibold text-sm md:text-base">Retour aux projets</span>
+      <span className="font-semibold text-sm md:text-base">{t('backToProjects')}</span>
     </button>
   );
 };
-
-export default BackToProjectsButton; 
+export default BackToProjectsButton;

--- a/src/app/components/Contact.tsx
+++ b/src/app/components/Contact.tsx
@@ -1,23 +1,19 @@
 'use client';
 
 import React from 'react';
+import { useTranslation } from '@/context/I18nContext';
 
 const Contact = () => {
+    const { t } = useTranslation();
     return (
         <section id="contact" className="pt-32 px-4">
             <div className="max-w-[1400px] mx-auto flex flex-col items-center">
                 <h2 className="text-center dark:text-[--primary-color] text-[--secondary-color] uppercase text-4xl font-bold mb-12">
-                    <span className="italic dark:text-white text-black">Me</span> Contacter
+                    <span className="italic dark:text-white text-black">{t('contact.title').split(' ')[0]}</span> {t('contact.title').split(' ')[1]}
                 </h2>
 
                 <div className="max-w-[800px] text-lg leading-7 text-black dark:text-white font-hk text-justify">
-                    <p className="mb-6">
-                        Vous êtes à la recherche d’un développeur, d’un intégrateur web ou encore d’un testeur pour renforcer votre équipe ? <br /><br />
-                        Je suis actuellement à la recherche d’une opportunité professionnelle et serais ravi d’échanger autour d’une future collaboration. <br /><br />
-
-                        N’hésitez pas à me contacter, que ce soit pour discuter d’un projet, en savoir plus sur mon profil, ou simplement me poser des questions. <br /><br />
-                        Je reste disponible et réactif, et je me ferai un plaisir de vous répondre.
-                    </p>
+                    <p className="mb-6" dangerouslySetInnerHTML={{__html: t('contact.paragraph')}} />
 
                     <a
                         href="mailto:contact@davyrobert.fr"

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -2,10 +2,12 @@
 
 import { motion } from "framer-motion"; // 👈 Import
 import React from "react";
+import { useTranslation } from "@/context/I18nContext";
 import { FaGithub, FaLinkedin } from "react-icons/fa";
 import { MdEmail } from "react-icons/md";
 
 const Footer = () => {
+   const { t } = useTranslation();
    return (
       <motion.footer
          id="contact"
@@ -51,10 +53,10 @@ const Footer = () => {
          {/* Copyright*/}
          <div className="mt-10 text-center space-y-2 mx-4">
             <p className="text-sm dark:text-gray-500 text-gray-900">
-               Design et Développement réalisés en NextJS & TailwindCSS
+               {t('footer.madeWith')}
             </p>
             <p className="text-sm text-[--secondary-color] dark:text-[--primary-color] font-semibold">
-               © 2025 Davy Robert – Tous droits réservés
+               {t('footer.rights')}
             </p>
          </div>
 

--- a/src/app/components/MesExperiences.tsx
+++ b/src/app/components/MesExperiences.tsx
@@ -3,9 +3,11 @@
 import Image from 'next/image'
 import React, { useEffect, useState } from 'react'
 import { data_experiences } from '@/datas/datas'
+import { useTranslation } from '@/context/I18nContext'
 
 const MesExperiences = () => {
    const [isMobile, setIsMobile] = useState(false)
+   const { t } = useTranslation()
 
    useEffect(() => {
       const handleResize = () => {
@@ -20,7 +22,7 @@ const MesExperiences = () => {
    return (
       <section id="experience" className="pt-32 px-4 text-[var(--text-color-dark)] dark:text-[var(--text-color-light)]">
          <h2 className="text-center text-[--primary-color] uppercase text-4xl font-bold mb-12">
-            <span className="italic text-[var(--text-color-dark)] dark:text-[var(--text-color-light)]">Mes</span> Expériences
+            {t('mesExperiences.title')}
          </h2>
 
          {isMobile ? (

--- a/src/app/components/MesProjets.tsx
+++ b/src/app/components/MesProjets.tsx
@@ -3,15 +3,17 @@
 import { motion } from "framer-motion";
 import { projects } from "@/datas/datas";
 import { ProjectCard } from "./ProjectCard";
+import { useTranslation } from '@/context/I18nContext';
 
 
 const MesProjets = () => {
    const maxTagsCount = projects.reduce((max, project) => Math.max(max, project.tags.length), 0);
+   const { t } = useTranslation();
 
    return (
       <section id="projets" className="pt-32 text-[var(--text-color-dark)] dark:text-[var(--text-color-light)] px-4">
          <h2 className="text-center text-[--primary-color] uppercase text-4xl font-bold mb-12">
-            <span className="italic text-[var(--text-color-dark)] dark:text-[var(--text-color-light)] bg-[var(--bg-light)] dark:bg-[var(--bg-dark)]">Mes</span> Projets <span className="font-mono">&</span> Réalisations
+            {t('mesProjets.title')}
          </h2>
 
          <div className='w-full flex'>
@@ -20,10 +22,8 @@ const MesProjets = () => {
                animate={{ opacity: 1 }}
                transition={{ delay: 0.2 }}
                className='text-secondary text-[18px] max-w-4xl leading-[28px] text-center mx-auto'
-            >
-               Découvrez mes projets réalisés, récents et à venir. Certains ont été déployés par mes soins et d&apos;autres l&apos;ont été dans un cadre professionnel en collaboration avec d&apos;autres développeurs. <br /> Par soucis de confidentialité, je ne pourrais pas fournir le code source des projets réalisés en entreprise. <br />
-               Toutefois, j&apos;ai réalisé quelques vidéos de démonstration afin d&apos;illustrer les fonctionnalités et l&apos;ergonomie de ces projets.
-            </motion.p>
+               dangerouslySetInnerHTML={{__html: t('mesProjets.intro')}}
+            />
          </div>
 
          <div className="mt-20 flex justify-center w-full">

--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -3,6 +3,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import React, { useEffect, useRef, useState } from 'react';
+import { useTranslation } from '@/context/I18nContext';
 import styles from './Navbar.module.css';
 import BurgerIcon from './ui/BurgerIcon';
 
@@ -14,6 +15,8 @@ const Navbar = () => {
    const [menuOpen, setMenuOpen] = useState(false);
    const [activeSection, setActiveSection] = useState<SectionId | null>(null);
    const navRef = useRef<HTMLDivElement>(null);
+   const { t, locale, setLocale } = useTranslation();
+   const toggleLocale = () => setLocale(locale === 'fr' ? 'en' : 'fr');
 
    useEffect(() => {
       // Intersection Observer to detect active section
@@ -116,30 +119,36 @@ const Navbar = () => {
                <ul className="flex flex-col md:flex-row gap-6 md:gap-9 items-center list-none">
                   <li>
                      <a href="#introduction" onClick={() => setMenuOpen(false)} className={`${styles.navLink} ${activeSection==='introduction'?'text-[--primary-color]':''}`}>
-                        A PROPOS
+                        {t('navbar.about')}
                      </a>
                   </li>
                   <li>
                      <a href="#skills" onClick={() => setMenuOpen(false)} className={`${styles.navLink} ${activeSection==='skills'?'text-[--primary-color]':''}`}>
-                        COMPÉTENCES
+                        {t('navbar.skills')}
                      </a>
                   </li>
                   <li>
                      <a href="#experience" onClick={() => setMenuOpen(false)} className={`${styles.navLink} ${activeSection==='experience'?'text-[--primary-color]':''}`}>
-                        EXPÉRIENCES
+                        {t('navbar.experience')}
                      </a>
                   </li>
                   <li>
                      <a href="#projets" onClick={() => setMenuOpen(false)} className={`${styles.navLink} ${activeSection==='projets'?'text-[--primary-color]':''}`}>
-                        PROJETS
+                        {t('navbar.projects')}
                      </a>
                   </li>
                   <li>
                      <a href="#contact" onClick={() => setMenuOpen(false)} className={`${styles.navLink} ${activeSection==='contact'?'text-[--primary-color]':''}`}>
-                        CONTACT
+                        {t('navbar.contact')}
                      </a>
                   </li>
                </ul>
+               <button
+                  onClick={toggleLocale}
+                  className="mt-6 md:mt-0 md:ml-4 border border-[--primary-color] px-2 py-1 rounded"
+               >
+                  {locale === 'fr' ? 'EN' : 'FR'}
+               </button>
                {menuOpen && (
                   <div className="md:hidden h-[1px] w-[100%] bg-[--primary-color] opacity-50 mx-auto mt-6" />
                )}

--- a/src/app/components/NavbarProjects.tsx
+++ b/src/app/components/NavbarProjects.tsx
@@ -28,4 +28,4 @@ const NavbarBackProjects = () => {
   );
 };
 
-export default NavbarBackProjects; 
+export default NavbarBackProjects;

--- a/src/app/components/Presentation.tsx
+++ b/src/app/components/Presentation.tsx
@@ -9,11 +9,13 @@ import MatrixCanvas from './ui/MatrixCanvas';
 import { useTheme } from '@/context/ThemeContext';
 import { qualities, methods } from '@/datas/datas';
 import Button from './ui/Button';
+import { useTranslation } from '@/context/I18nContext';
 
 const Presentation = () => {
    const sectionRef = useRef<HTMLElement>(null);
    const { theme } = useTheme();
    const [mounted, setMounted] = useState(false);
+   const { t } = useTranslation();
 
    useEffect(() => {
       setMounted(true);
@@ -30,15 +32,13 @@ const Presentation = () => {
 
          {/* Présentation texte */}
          <div id="presentation" className="relative z-10 w-full max-w-[700px] text-left mb-8 lg:mb-0">
-            <h2 className="text-4xl font-bold text-center lg:text-left">Bonjour je me présente</h2>
+            <h2 className="text-4xl font-bold text-center lg:text-left">{t('presentation.hello')}</h2>
             <h1 className="text-[64px] my-4 font-bold text-center lg:text-left">
                <span className="italic font-light">Davy</span>{' '}
                <span className="">ROBERT</span>
             </h1>
             <h2 className="text-4xl font-bold mb-6 text-center lg:text-left">
-               Et j&#39;exerce en tant que <br />
-               <span className="text-[--primary-color]">Développeur Full</span>{' '}
-               <span className="text-[--primary-color]">Stack</span>
+               {t('presentation.fullstack')}
             </h2>
 
             {/* Image profil <=1024px */}
@@ -54,7 +54,7 @@ const Presentation = () => {
 
             <div className="flex flex-col xl:flex-row items-center lg:items-start my-6 gap-2 xl:gap-4">
               <span className="text-lg font-bold text-[--primary-color] mb-2 xl:mb-0 flex items-center gap-2 min-w-max">
-                Méthodes adoptées :
+                {t('presentation.methodsTitle')}
               </span>
               <div className="flex flex-row flex-wrap gap-2 xl:gap-4 lg:justify-start mt-0 justify-center">
                 {methods.items.map((m) => (
@@ -96,7 +96,7 @@ const Presentation = () => {
                   href="/download/CV_davy_robert_2025.pdf"
                   download
                >
-                  Mon CV format standard
+                  {t('presentation.cvStandard')}
                </Button>
                <Button
                   variant="secondary"
@@ -104,7 +104,7 @@ const Presentation = () => {
                   download
                   withShineEffect
                >
-                  Mon CV format long
+                  {t('presentation.cvLong')}
                </Button>
                <div className="flex w-full justify-center sm:w-auto sm:justify-start gap-8 sm:mt-0 mt-4">
                   <a

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import Script from "next/script";
 import { geistMono, geistSans, spaceGrotesk, spaceGrotesk500, spaceGrotesk600, spaceGrotesk700 } from "../utils/fonts";
 import Footer from "./components/Footer";
 import ThemeToggle from "./components/ui/ThemeToggle";
+import { I18nProvider } from "@/context/I18nContext";
 
 export const metadata: Metadata = {
    title: "Davy Robert - Portfolio",
@@ -25,6 +26,7 @@ export default async function RootLayout({
             <Script id="theme-init" strategy="beforeInteractive">
                {THEME_INIT_SCRIPT}
             </Script>
+            <I18nProvider>
             <ThemeProvider>
                {isMaintenanceMode ? (
                   <div className="h-screen flex justify-center items-center font-medium text-3xl text-center dark:bg-[var(--bg-dark)] dark:text-[var(--text-color-light)]">
@@ -40,6 +42,7 @@ export default async function RootLayout({
                   </>
                )}
             </ThemeProvider>
+            </I18nProvider>
          </body>
       </html>
    );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,12 +2,13 @@
 
 import React, { Suspense } from "react";
 import HomeContent from "./HomeContent";
-
+import { useTranslation } from "@/context/I18nContext";
 
 export default function Home() {
+  const { t } = useTranslation();
   return (
     <main className="flex-1 px-2 sm:px-8 pb-20 gap-16 font-grotesk font-[800] dark:bg-[var(--bg-dark)] dark:text-[var(--text-color-light)] text-[var(--text-color-dark)]">
-      <Suspense fallback={<div>Chargement...</div>}>
+      <Suspense fallback={<div>{t('loading')}</div>}>
         <HomeContent />
       </Suspense>
     </main>

--- a/src/app/projects/[slug]/page.js
+++ b/src/app/projects/[slug]/page.js
@@ -1,8 +1,10 @@
+'use client'
 import { projects } from '@/datas/datas';
 import Image from 'next/image';
 import { notFound } from 'next/navigation';
 import NavbarBackProjects from '@/app/components/NavbarProjects';
 import BackToProjectsButton from '@/app/components/BackToProjectsButton';
+import { useTranslation } from '@/context/I18nContext';
 
 export default async function ProjectPage({ params }) {
   const { slug } = await params;
@@ -10,6 +12,7 @@ export default async function ProjectPage({ params }) {
 
   if (!project) return notFound();
 
+  const { t } = useTranslation();
   return (
     <section className="max-w-[1400px] mx-auto px-6 py-8 text-black dark:text-white">
       <NavbarBackProjects />
@@ -44,7 +47,7 @@ export default async function ProjectPage({ params }) {
             rel="noopener noreferrer"
             className="text-[--primary-color] hover:text-[--primary-color] hover:font-bold"
           >
-            VOIR LE PROJET
+            {t('project.viewProject')}
           </a>
         )}
       </div>

--- a/src/context/I18nContext.tsx
+++ b/src/context/I18nContext.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import React, {createContext, useContext, useState, useEffect, ReactNode} from 'react';
+import fr from '../locales/fr.json';
+import en from '../locales/en.json';
+
+export type Locale = 'fr' | 'en';
+
+interface I18nContextValue {
+  locale: Locale;
+  setLocale: (l: Locale) => void;
+  t: (key: string) => string;
+}
+
+const messages: Record<Locale, Record<string, string>> = { fr, en };
+
+const I18nContext = createContext<I18nContextValue | undefined>(undefined);
+
+export function I18nProvider({ children }: { children: ReactNode }) {
+  const [locale, setLocale] = useState<Locale>('fr');
+  const [dict, setDict] = useState(messages['fr']);
+
+  useEffect(() => {
+    setDict(messages[locale]);
+  }, [locale]);
+
+  function t(key: string) {
+    return dict[key] || key;
+  }
+
+  return (
+    <I18nContext.Provider value={{ locale, setLocale, t }}>
+      {children}
+    </I18nContext.Provider>
+  );
+}
+
+export function useTranslation() {
+  const ctx = useContext(I18nContext);
+  if (!ctx) throw new Error('useTranslation must be used within an I18nProvider');
+  return ctx;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,23 @@
+{
+  "navbar.about": "ABOUT",
+  "navbar.skills": "SKILLS",
+  "navbar.experience": "EXPERIENCE",
+  "navbar.projects": "PROJECTS",
+  "navbar.contact": "CONTACT",
+  "presentation.hello": "Hello, let me introduce myself",
+  "presentation.fullstack": "And I work as a Full Stack Developer",
+  "presentation.methodsTitle": "Methods used:",
+  "presentation.cvStandard": "Standard CV",
+  "presentation.cvLong": "Extended CV",
+  "mesProjets.title": "My Projects & Achievements",
+  "mesProjets.intro": "Discover my completed, recent and upcoming projects. Some have been deployed by me and others professionally in collaboration with other developers. <br /> For confidentiality reasons, I cannot provide the source code of projects made in companies. <br /> However, I have created some demo videos to showcase the features and ergonomics of these projects.",
+  "mesExperiences.title": "My Experiences",
+  "contact.title": "Contact Me",
+  "contact.paragraph": "Are you looking for a developer, a web integrator or even a tester to strengthen your team? <br /><br /> I am currently seeking a professional opportunity and would be delighted to discuss a future collaboration. <br /><br /> Feel free to contact me to talk about a project, learn more about my profile or simply ask questions. <br /><br /> I remain available and responsive, and I will be happy to reply.",
+  "footer.madeWith": "Design and Development made with NextJS & TailwindCSS",
+  "footer.rights": "© 2025 Davy Robert – All rights reserved",
+  "backToProjects": "Back to projects",
+  "project.viewProject": "VIEW PROJECT",
+  "maintenance": "The site is currently under development. \nPlease wait...",
+  "loading": "Loading..."
+}

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1,0 +1,23 @@
+{
+  "navbar.about": "A PROPOS",
+  "navbar.skills": "COMPÉTENCES",
+  "navbar.experience": "EXPÉRIENCES",
+  "navbar.projects": "PROJETS",
+  "navbar.contact": "CONTACT",
+  "presentation.hello": "Bonjour je me présente",
+  "presentation.fullstack": "Et j'exerce en tant que Développeur Full Stack",
+  "presentation.methodsTitle": "Méthodes adoptées :",
+  "presentation.cvStandard": "Mon CV format standard",
+  "presentation.cvLong": "Mon CV format long",
+  "mesProjets.title": "Mes Projets & Réalisations",
+  "mesProjets.intro": "Découvrez mes projets réalisés, récents et à venir. Certains ont été déployés par mes soins et d'autres l'ont été dans un cadre professionnel en collaboration avec d'autres développeurs. <br /> Par soucis de confidentialité, je ne pourrais pas fournir le code source des projets réalisés en entreprise. <br /> Toutefois, j'ai réalisé quelques vidéos de démonstration afin d'illustrer les fonctionnalités et l'ergonomie de ces projets.",
+  "mesExperiences.title": "Mes Expériences",
+  "contact.title": "Me Contacter",
+  "contact.paragraph": "Vous êtes à la recherche d’un développeur, d’un intégrateur web ou encore d’un testeur pour renforcer votre équipe ? <br /><br /> Je suis actuellement à la recherche d’une opportunité professionnelle et serais ravi d’échanger autour d’une future collaboration. <br /><br /> N’hésitez pas à me contacter, que ce soit pour discuter d’un projet, en savoir plus sur mon profil, ou simplement me poser des questions. <br /><br /> Je reste disponible et réactif, et je me ferai un plaisir de vous répondre.",
+  "footer.madeWith": "Design et Développement réalisés en NextJS & TailwindCSS",
+  "footer.rights": "© 2025 Davy Robert – Tous droits réservés",
+  "backToProjects": "Retour aux projets",
+  "project.viewProject": "VOIR LE PROJET",
+  "maintenance": "Le site est actuellement en cours d'élaboration. \nVeuillez patienter...............",
+  "loading": "Chargement..."
+}


### PR DESCRIPTION
## Summary
- create translation context and translation files
- wire up provider in layout and navigation
- translate main UI texts and add language toggle
- configure Next.js i18n routing

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884cd2b63ac8323833d3db709e70d2c